### PR TITLE
refactor: 커뮤니티 관리 권한 시스템 개선 및 상태 배지 통합

### DIFF
--- a/src/features/community/components/comments/CommentDetailModal.tsx
+++ b/src/features/community/components/comments/CommentDetailModal.tsx
@@ -32,6 +32,7 @@ import { FiExternalLink } from 'react-icons/fi'
 import { useState, useEffect } from 'react'
 import { commentService } from '../../services/commentService'
 import { formatDate } from '@/utils/date'
+import { getContentStatusBadge } from '@/utils/statusBadge'
 import { REPORT_REASON_LABELS, type ReportReason } from '../../types'
 import type { CommentReportWithDetails } from '../../services/commentReportService'
 
@@ -174,21 +175,6 @@ const CommentDetailModal = ({
     }
   }
 
-  const getStatusBadge = (status: string) => {
-    const statusConfig = {
-      active: { colorScheme: 'green', label: '활성' },
-      hidden: { colorScheme: 'yellow', label: '숨김' },
-      deleted: { colorScheme: 'red', label: '삭제' },
-      pending: { colorScheme: 'gray', label: '대기' },
-    }
-
-    const config = statusConfig[status as keyof typeof statusConfig] || {
-      colorScheme: 'gray',
-      label: status,
-    }
-
-    return <Badge colorScheme={config.colorScheme}>{config.label}</Badge>
-  }
 
 
   if (!isOpen || (!commentId && !existingCommentData)) return null
@@ -255,7 +241,7 @@ const CommentDetailModal = ({
                           )}
                         </VStack>
                       </HStack>
-                      {getStatusBadge(comment.status)}
+                      {getContentStatusBadge(comment.status as any)}
                     </HStack>
 
                     <Divider />
@@ -410,16 +396,6 @@ const CommentDetailModal = ({
 
         <ModalFooter>
           <HStack spacing={2}>
-            {currentStatus === 'hidden' && (
-              <Button
-                size='sm'
-                colorScheme='green'
-                onClick={() => handleStatusChange('active')}
-                isLoading={updateStatusMutation.isPending}
-              >
-                활성화
-              </Button>
-            )}
             {currentStatus === 'active' && (
               <Button
                 size='sm'
@@ -430,15 +406,21 @@ const CommentDetailModal = ({
                 숨기기
               </Button>
             )}
-            <Button
-              size='sm'
-              colorScheme='red'
-              onClick={() => handleStatusChange('deleted')}
-              isLoading={updateStatusMutation.isPending}
-              isDisabled={currentStatus === 'deleted'}
-            >
-              삭제
-            </Button>
+            {currentStatus === 'hidden' && (
+              <Button
+                size='sm'
+                colorScheme='green'
+                onClick={() => handleStatusChange('active')}
+                isLoading={updateStatusMutation.isPending}
+              >
+                활성화
+              </Button>
+            )}
+            {currentStatus === 'deleted' && (
+              <Text color='gray.500' fontSize='sm'>
+                사용자가 삭제한 댓글입니다. 관리자는 수정할 수 없습니다.
+              </Text>
+            )}
             <Button variant='outline' onClick={onClose} ml={3}>
               닫기
             </Button>

--- a/src/features/community/components/comments/CommentItem.tsx
+++ b/src/features/community/components/comments/CommentItem.tsx
@@ -14,6 +14,7 @@ import {
 } from '@chakra-ui/react'
 import { FiMoreHorizontal, FiHeart, FiMessageCircle } from 'react-icons/fi'
 import { formatDate } from '@/utils/date'
+import { getContentStatusBadge } from '@/utils/statusBadge'
 import type { CommunityCommentWithAuthor } from '../../services/commentService'
 
 interface CommentItemProps {
@@ -28,21 +29,6 @@ const CommentItem = ({ comment, depth = 0, onStatusChange, isLoading }: CommentI
   const bgColor = useColorModeValue('white', 'gray.800')
   const replyBg = useColorModeValue('gray.50', 'gray.700')
 
-  const getStatusBadge = (status: string) => {
-    const statusConfig = {
-      active: { colorScheme: 'green', label: '활성' },
-      hidden: { colorScheme: 'yellow', label: '숨김' },
-      deleted: { colorScheme: 'red', label: '삭제' },
-      pending: { colorScheme: 'gray', label: '대기' },
-    }
-
-    const config = statusConfig[status as keyof typeof statusConfig] || {
-      colorScheme: 'gray',
-      label: status,
-    }
-
-    return <Badge size="sm" colorScheme={config.colorScheme}>{config.label}</Badge>
-  }
 
   const handleStatusChange = (newStatus: string) => {
     if (onStatusChange) {
@@ -93,7 +79,7 @@ const CommentItem = ({ comment, depth = 0, onStatusChange, isLoading }: CommentI
             </HStack>
 
             <HStack spacing={2}>
-              {getStatusBadge(comment.status)}
+              {getContentStatusBadge(comment.status as any)}
               <Menu>
                 <MenuButton
                   as={IconButton}
@@ -104,15 +90,24 @@ const CommentItem = ({ comment, depth = 0, onStatusChange, isLoading }: CommentI
                   isLoading={isLoading}
                 />
                 <MenuList>
-                  <MenuItem onClick={() => handleStatusChange('active')}>
-                    활성화
-                  </MenuItem>
-                  <MenuItem onClick={() => handleStatusChange('hidden')}>
-                    숨기기
-                  </MenuItem>
-                  <MenuItem onClick={() => handleStatusChange('deleted')}>
-                    삭제
-                  </MenuItem>
+                  {comment.status === 'deleted' ? (
+                    <MenuItem isDisabled>
+                      관리자는 수정할 수 없습니다
+                    </MenuItem>
+                  ) : (
+                    <>
+                      {comment.status === 'hidden' && (
+                        <MenuItem onClick={() => handleStatusChange('active')}>
+                          활성화
+                        </MenuItem>
+                      )}
+                      {comment.status === 'active' && (
+                        <MenuItem onClick={() => handleStatusChange('hidden')}>
+                          숨기기
+                        </MenuItem>
+                      )}
+                    </>
+                  )}
                 </MenuList>
               </Menu>
             </HStack>

--- a/src/features/community/components/reports/CommentReportList.tsx
+++ b/src/features/community/components/reports/CommentReportList.tsx
@@ -29,7 +29,7 @@ import {
 } from '../../services/commentReportService'
 import { REPORT_REASON_LABELS } from '../../types'
 import { formatDate } from '@/utils/date'
-import { getPostStatusBadge } from '@/utils/statusBadge'
+import { getContentStatusBadge } from '@/utils/statusBadge'
 import { truncateText } from '@/utils/textUtils'
 import CommentDetailModal from '../comments/CommentDetailModal'
 
@@ -247,7 +247,7 @@ const CommentReportList = ({ initialFilters = {} }: CommentReportListProps) => {
                 </Td>
                 <Td>
                   {report.comment?.status ? (
-                    getPostStatusBadge(report.comment.status)
+                    getContentStatusBadge(report.comment.status)
                   ) : (
                     <Badge colorScheme='gray' size='sm'>
                       알 수 없음

--- a/src/features/community/components/reports/CommunityReportList.tsx
+++ b/src/features/community/components/reports/CommunityReportList.tsx
@@ -31,7 +31,7 @@ import {
   REPORT_REASON_LABELS,
 } from '../../types'
 import { formatDate } from '@/utils/date'
-import { getPostStatusBadge } from '@/utils/statusBadge'
+import { getContentStatusBadge } from '@/utils/statusBadge'
 import { truncateText } from '@/utils/textUtils'
 
 interface CommunityReportListProps {
@@ -313,8 +313,8 @@ const CommunityReportList = ({ initialFilters = {} }: CommunityReportListProps) 
                   </VStack>
                 </Td>
                 <Td>
-                  {report.post?.status && getPostStatusBadge(report.post.status)}
-                  {report.comment?.status && getPostStatusBadge(report.comment.status)}
+                  {report.post?.status && getContentStatusBadge(report.post.status)}
+                  {report.comment?.status && getContentStatusBadge(report.comment.status)}
                   {!report.post && !report.comment && (
                     <Text fontSize='sm' color='gray.500'>
                       -

--- a/src/features/community/components/reports/PostReportList.tsx
+++ b/src/features/community/components/reports/PostReportList.tsx
@@ -31,7 +31,7 @@ import {
   REPORT_REASON_LABELS,
 } from '../../types'
 import { formatDate } from '@/utils/date'
-import { getPostStatusBadge } from '@/utils/statusBadge'
+import { getContentStatusBadge } from '@/utils/statusBadge'
 import { truncateText } from '@/utils/textUtils'
 
 interface PostReportListProps {
@@ -247,7 +247,7 @@ const PostReportList = ({ initialFilters = {} }: PostReportListProps) => {
                 </Td>
                 <Td>
                   {report.post?.status ? (
-                    getPostStatusBadge(report.post.status)
+                    getContentStatusBadge(report.post.status)
                   ) : (
                     <Badge colorScheme='gray' size='sm'>
                       알 수 없음

--- a/src/features/community/services/postService.ts
+++ b/src/features/community/services/postService.ts
@@ -146,10 +146,36 @@ class PostService {
   }
 
   /**
-   * 게시글 상태 업데이트
+   * 게시글 상태 업데이트 (관리자 권한 검증 포함)
    */
   async updatePostStatus(id: string, status: string): Promise<void> {
     try {
+      // 현재 게시글 상태 확인
+      const { data: currentPost, error: fetchError } = await supabase
+        .from('community_writing_list')
+        .select('status')
+        .eq('id', id)
+        .single()
+
+      if (fetchError) {
+        console.error('게시글 조회 오류:', fetchError)
+        throw new Error('게시글을 찾을 수 없습니다.')
+      }
+
+      // 관리자 권한 검증
+      if (currentPost.status === 'deleted') {
+        throw new Error('사용자가 삭제한 게시글은 관리자가 수정할 수 없습니다.')
+      }
+
+      if (status === 'deleted') {
+        throw new Error('관리자는 게시글을 삭제할 수 없습니다. 숨김 처리를 사용하세요.')
+      }
+
+      // active ↔ hidden만 허용
+      if (!['active', 'hidden'].includes(status)) {
+        throw new Error('허용되지 않는 상태 변경입니다.')
+      }
+
       const { error } = await supabase
         .from('community_writing_list')
         .update({ status, updated_at: new Date().toISOString() })

--- a/src/utils/statusBadge.tsx
+++ b/src/utils/statusBadge.tsx
@@ -1,24 +1,69 @@
-import { Badge } from '@chakra-ui/react'
-import { POST_STATUS_LABELS, type PostStatus } from '@/features/community/types'
+import { Badge, HStack, Tooltip } from '@chakra-ui/react'
+import { FiLock } from 'react-icons/fi'
+import type { PostStatus } from '@/features/community/types'
+
+// 댓글과 게시물이 동일한 상태를 사용
+type ContentStatus = PostStatus
+
+// 통합 상태 라벨 (관리자/사용자 행동 명시)
+const CONTENT_STATUS_LABELS: Record<ContentStatus, string> = {
+  'active': '활성',
+  'hidden': '관리자 숨김',
+  'deleted': '사용자 삭제'
+}
+
+// 핵심 상태 설정 (라벨은 별도 관리)
+interface StatusConfig {
+  colorScheme: string
+  readonly: boolean
+}
+
+// 공통 상태 설정 (색상과 권한만)
+const STATUS_CONFIGS: Record<ContentStatus, StatusConfig> = {
+  active: { colorScheme: 'green', readonly: false },
+  hidden: { colorScheme: 'yellow', readonly: false },
+  deleted: { colorScheme: 'red', readonly: true },
+}
 
 /**
- * 게시물 상태에 따른 배지 컴포넌트 생성
+ * 공통 상태 배지 생성 헬퍼 함수
  */
-export const getPostStatusBadge = (status: PostStatus) => {
-  const statusConfig = {
-    active: { colorScheme: 'green', label: '🟢 활성', icon: '🟢' },
-    hidden: { colorScheme: 'yellow', label: '🟡 숨김', icon: '🟡' },
-    deleted: { colorScheme: 'red', label: '🔴 삭제', icon: '🔴' },
+function createStatusBadge(
+  status: ContentStatus,
+  statusLabels: Record<ContentStatus, string>,
+  showAdminInfo = true
+) {
+  const config = STATUS_CONFIGS[status]
+
+  const badge = (
+    <Badge colorScheme={config.colorScheme} size="sm">
+      {statusLabels[status]}
+    </Badge>
+  )
+
+  if (showAdminInfo && config.readonly) {
+    return (
+      <HStack spacing={1}>
+        {badge}
+        <Tooltip label="관리자는 수정할 수 없습니다">
+          <FiLock size={12} color="#9CA3AF" />
+        </Tooltip>
+      </HStack>
+    )
   }
 
-  const config = statusConfig[status] || {
-    colorScheme: 'gray',
-    label: status,
-    icon: '❓',
-  }
-
-  return <Badge colorScheme={config.colorScheme} size='sm'>{POST_STATUS_LABELS[status]}</Badge>
+  return badge
 }
+
+/**
+ * 컨텐츠 상태 배지 생성 (게시물/댓글 공통)
+ * @param status - 컨텐츠 상태 ('active' | 'hidden' | 'deleted')
+ * @param showAdminInfo - 관리자 권한 정보 표시 여부 (기본: true)
+ */
+export const getContentStatusBadge = (status: PostStatus, showAdminInfo = true) => {
+  return createStatusBadge(status, CONTENT_STATUS_LABELS, showAdminInfo)
+}
+
 
 /**
  * 일반 상태에 따른 배지 컴포넌트 생성


### PR DESCRIPTION
- 관리자 권한 제한: 사용자 삭제 컨텐츠는 읽기 전용으로 변경
- 상태 변경 정책: 관리자는 활성↔숨김만 가능, 삭제는 사용자 전용
- 서비스 레이어 검증: commentService, postService에 권한 검증 로직 추가
- UI 개선: 삭제된 컨텐츠에 잠금 아이콘 및 비활성화 메뉴 표시
- 코드 통합: getPostStatusBadge, getCommentStatusBadge → getContentStatusBadge로 일원화
- React ref 오류 수정: FiLock 컴포넌트 직접 사용으로 변경

🤖 Generated with [Claude Code](https://claude.ai/code)