### PR TITLE
fix(community): 관리자 상태 변경 시 수정일 자동 업데이트 문제 수정 및 버튼 일관성 개선

### DIFF
--- a/src/features/community/components/comments/CommentDetailModal.tsx
+++ b/src/features/community/components/comments/CommentDetailModal.tsx
@@ -413,7 +413,7 @@ const CommentDetailModal = ({
                 onClick={() => handleStatusChange('active')}
                 isLoading={updateStatusMutation.isPending}
               >
-                활성화
+                복원
               </Button>
             )}
             {currentStatus === 'deleted' && (

--- a/src/features/community/components/comments/CommentItem.tsx
+++ b/src/features/community/components/comments/CommentItem.tsx
@@ -98,7 +98,7 @@ const CommentItem = ({ comment, depth = 0, onStatusChange, isLoading }: CommentI
                     <>
                       {comment.status === 'hidden' && (
                         <MenuItem onClick={() => handleStatusChange('active')}>
-                          활성화
+                          복원
                         </MenuItem>
                       )}
                       {comment.status === 'active' && (

--- a/src/features/community/services/commentService.ts
+++ b/src/features/community/services/commentService.ts
@@ -180,7 +180,7 @@ class CommentService {
 
       const { error } = await supabase
         .from('community_comments_list')
-        .update({ status, updated_at: new Date().toISOString() })
+        .update({ status })
         .eq('id', id)
 
       if (error) {

--- a/src/features/community/services/postService.ts
+++ b/src/features/community/services/postService.ts
@@ -178,7 +178,7 @@ class PostService {
 
       const { error } = await supabase
         .from('community_writing_list')
-        .update({ status, updated_at: new Date().toISOString() })
+        .update({ status })
         .eq('id', id)
 
       if (error) {


### PR DESCRIPTION
- 게시글/댓글 상태 변경 시 updated_at 자동 업데이트 제거
  - postService.updatePostStatus에서 updated_at 제거
  - commentService.updateCommentStatus에서 updated_at 제거
  - 작성자 수정 시에만 updated_at이 변경되도록 개선

- 댓글 관리 UI 버튼 일관성 개선
  - CommentItem과 CommentDetailModal에서 "활성화" → "복원" 버튼명 변경
  - 게시글 관리와 동일한 버튼명으로 통일

관리자의 숨기기/복원 액션과 작성자의 실제 수정을 명확히 구분하여
더 정확한 수정일 추적이 가능하도록 개선

🤖 Generated with [Claude Code](https://claude.ai/code)