### PR TITLE
fix(community): 신고된 댓글 상세보기 개선 및 타입 오류 수정

### DIFF
--- a/src/features/community/services/commentReportService.ts
+++ b/src/features/community/services/commentReportService.ts
@@ -133,6 +133,31 @@ class CommentReportService {
   }
 
   /**
+   * 특정 댓글의 모든 신고 내역 조회
+   */
+  async getCommentReportsByCommentId(commentId: string): Promise<CommentReportWithDetails[]> {
+    try {
+      const { data, error } = await supabase
+        .from('community_reports')
+        .select('*')
+        .eq('comment_id', commentId)
+        .order('created_at', { ascending: false })
+
+      if (error) {
+        console.error('댓글 신고 내역 조회 오류:', error)
+        throw new Error('댓글 신고 내역을 불러오는데 실패했습니다.')
+      }
+
+      // 댓글 정보 추가
+      const enrichedData = await this.enrichCommentReportsWithContent(data || [])
+      return enrichedData
+    } catch (error) {
+      console.error('CommentReportService.getCommentReportsByCommentId 오류:', error)
+      throw error
+    }
+  }
+
+  /**
    * 댓글 신고 통계 조회
    */
   async getCommentReportStats() {


### PR DESCRIPTION
- 동일한 댓글 ID의 모든 신고 내역 표시 기능 추가
- 신고 사유별 통계 UI를 박스형 레이아웃으로 개선하여 가독성 향상
- CommentReportService에 특정 댓글의 모든 신고 조회 메서드 추가
- created_at/updated_at 필드 참조 타입 오류 수정
- React Hook 조건부 호출 ESLint 오류 해결

기존에는 하나의 댓글에 여러 신고가 있어도 하나만 표시되었으나,
이제 모든 신고 내역과 정확한 사유별 통계를 제공함.

🤖 Generated with [Claude Code](https://claude.ai/code)