### PR TITLE
fix: Vercel에서 SPA 새로고침 404 오류 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
vercel.json rewrites 설정으로 모든 경로를 index.html로 리다이렉트

🤖 Generated with [Claude Code](https://claude.ai/code)